### PR TITLE
Cleanup cleanup (in VersionedStore)

### DIFF
--- a/scalding-commons/src/main/java/com/twitter/scalding/commons/datastores/VersionedStore.java
+++ b/scalding-commons/src/main/java/com/twitter/scalding/commons/datastores/VersionedStore.java
@@ -128,18 +128,12 @@ public class VersionedStore {
     }
 
     public void cleanup(int versionsToKeep) throws IOException {
+        if (versionsToKeep < 0) return;
         final List<Long> versions = getAllVersions();
-        final HashSet<Long> keepers;
-        if(versionsToKeep >= 0) {
-            keepers = new HashSet<Long>(versions.subList(0, Math.min(versions.size(), versionsToKeep)));
-        } else {
-            keepers = new HashSet<Long>(versions);
-        }
-
-        for(Long v : versions) {
-            if(v!=null && !keepers.contains(v)) {
-                    deleteVersion(v);
-            }
+        int numExisting = versions.size(); 
+        if (numExisting <= versionsToKeep) return;
+        for (Long v : versions.subList(versionsToKeep, numExisting)) {
+            deleteVersion(v);
         }
     }
 


### PR DESCRIPTION
Friends don't let friends use a HashSet just to traverse a sorted list's tail ....